### PR TITLE
mismatching end quotes cause error when trying to import in Android Studio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+’
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 

--- a/fancybuttons_library/build.gradle
+++ b/fancybuttons_library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.1.0”
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
Looks like a previous change modified the end quotes. I'm using Android Studio on a Windows device, and this issue prevents the project from being imported.
