### PR TITLE
Fix issue where fontIcon and button text are not center aligned when button width is match_parent

### DIFF
--- a/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
+++ b/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
@@ -1,6 +1,5 @@
 package mehdi.sakout.fancybuttons;
 
-import java.util.ArrayList;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -16,8 +15,9 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.TableLayout;
 import android.widget.TextView;
+
+import java.util.ArrayList;
 
 @SuppressWarnings("unused")
 public class FancyButton  extends LinearLayout{
@@ -179,7 +179,7 @@ public class FancyButton  extends LinearLayout{
             textView.setTextColor(mDefaultTextColor);
             textView.setTextSize(mDefaultTextSize);
 
-            textView.setLayoutParams(new TableLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, 1f));
+            textView.setLayoutParams(new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
             if (!isInEditMode() && mTextTypeFace!=null) {
                 textView.setTypeface(mTextTypeFace);
             }
@@ -198,7 +198,7 @@ public class FancyButton  extends LinearLayout{
             TextView fontIconView = new TextView(mContext);
             fontIconView.setTextColor(mDefaultIconColor);
 
-            LayoutParams iconTextViewParams = new LayoutParams(LayoutParams.MATCH_PARENT,LayoutParams.WRAP_CONTENT,1f);
+            LayoutParams iconTextViewParams = new LayoutParams(LayoutParams.WRAP_CONTENT,LayoutParams.WRAP_CONTENT);
             iconTextViewParams.rightMargin = mIconPaddingRight;
             iconTextViewParams.leftMargin = mIconPaddingLeft;
             iconTextViewParams.topMargin = mIconPaddingTop;
@@ -404,7 +404,7 @@ public class FancyButton  extends LinearLayout{
         }
         LayoutParams containerParams = new LayoutParams(LayoutParams.WRAP_CONTENT,LayoutParams.WRAP_CONTENT);
         this.setLayoutParams(containerParams);
-        this.setGravity(Gravity.CENTER_VERTICAL);
+        this.setGravity(Gravity.CENTER);
         this.setClickable(true);
         this.setFocusable(true);
         if(mIconResource==null && mFontIcon==null && getPaddingLeft()==0 && getPaddingRight()==0 && getPaddingTop()==0 && getPaddingBottom()==0){


### PR DESCRIPTION
My original problem:

```xml
<mehdi.sakout.fancybuttons.FancyButton
                android:id="@+id/buttonChangePassword"
                android:layout_width="match_parent"
                android:layout_height="wrap_content"
                android:paddingBottom="10dp"
                android:paddingLeft="20dp"
                android:paddingRight="20dp"
                android:paddingTop="10dp"
                android:layout_marginBottom="25dp"
                fancy:fb_defaultColor="#FF574E"
                fancy:fb_radius="3dp"
                fancy:fb_text="@string/changePassword"
                fancy:fb_textColor="#FFFFFF"
                fancy:fb_textFont="cg_regular.ttf"
                fancy:fb_fontIconResource="&#xf084;"
                fancy:fb_iconPosition="left"
                />
```

Setting the layout_width to wrap_content works fine, but match_parent will align the icon to the left and the text to the right of the button.

EDIT: Add screenshot of the button as I see it. Ideally the text + icon should be centered in the button.

![Imgur](http://i.imgur.com/sOuQy2L.png)

EDIT2: If fb_iconPosition is top or bottom, text gravity works fine. If fb_iconPosition is right, text gravity defaults to left.