### PR TITLE
Ripple effect no shown in transparent button fixed

### DIFF
--- a/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
+++ b/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
@@ -10,7 +10,9 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
+import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.StateListDrawable;
+import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -335,8 +337,8 @@ public class FancyButton  extends LinearLayout{
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private Drawable getRippleDrawable(Drawable contentDrawable){
-        return new RippleDrawable(ColorStateList.valueOf(mFocusBackgroundColor), contentDrawable, null);
+    private Drawable getRippleDrawable(Drawable defaultDrawable, Drawable focusDrawable){
+        return new RippleDrawable(ColorStateList.valueOf(mFocusBackgroundColor), defaultDrawable, focusDrawable);
     }
 
 
@@ -345,23 +347,28 @@ public class FancyButton  extends LinearLayout{
 
 
         // Default Drawable
-        GradientDrawable drawable = new GradientDrawable();
-        drawable.setCornerRadius(mRadius);
+        GradientDrawable defaultDrawable = new GradientDrawable();
+        defaultDrawable.setCornerRadius(mRadius);
         if (mGhost){
-            drawable.setColor(getResources().getColor(android.R.color.transparent)); // Hollow Background
+            defaultDrawable.setColor(getResources().getColor(android.R.color.transparent)); // Hollow Background
         } else {
-            drawable.setColor(mDefaultBackgroundColor);
+            defaultDrawable.setColor(mDefaultBackgroundColor);
         }
+
+        //Focus Drawable
+        GradientDrawable focusDrawable = new GradientDrawable();
+        focusDrawable.setCornerRadius(mRadius);
+        focusDrawable.setColor(mFocusBackgroundColor);
 
         // Handle Border
         if (mBorderColor != 0) {
-            drawable.setStroke(mBorderWidth, mBorderColor);
+            defaultDrawable.setStroke(mBorderWidth, mBorderColor);
         }
 
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 
-            this.setBackground(getRippleDrawable(drawable));
+            this.setBackground(getRippleDrawable(defaultDrawable, focusDrawable));
 
         } else {
 
@@ -390,7 +397,7 @@ public class FancyButton  extends LinearLayout{
                 states.addState(new int[] { android.R.attr.state_pressed }, drawable2);
                 states.addState(new int[] { android.R.attr.state_focused }, drawable2);
             }
-            states.addState(new int[]{}, drawable);
+            states.addState(new int[]{}, defaultDrawable);
 
             if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN) {
                 this.setBackgroundDrawable(states);

--- a/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
+++ b/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
@@ -10,9 +10,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
-import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.StateListDrawable;
-import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -21,6 +19,7 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
 import java.util.ArrayList;
 
 @SuppressWarnings("unused")

--- a/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
+++ b/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
@@ -55,6 +55,8 @@ public class FancyButton  extends LinearLayout{
 
     private int mRadius 						= 0;
 
+    private boolean mTextAllCaps                = false;
+
     private Typeface mTextTypeFace = null;
     private Typeface mIconTypeFace = null;
 
@@ -291,6 +293,8 @@ public class FancyButton  extends LinearLayout{
         mIconPaddingTop                 = (int)attrsArray.getDimension(R.styleable.FancyButtonsAttrs_fb_iconPaddingTop,mIconPaddingTop);
         mIconPaddingBottom              = (int)attrsArray.getDimension(R.styleable.FancyButtonsAttrs_fb_iconPaddingBottom,mIconPaddingBottom);
 
+        mTextAllCaps                    = attrsArray.getBoolean(R.styleable.FancyButtonsAttrs_fb_textAllCaps, false);
+
         mGhost = attrsArray.getBoolean(R.styleable.FancyButtonsAttrs_fb_ghost, mGhost);
 
         String text 					= attrsArray.getString(R.styleable.FancyButtonsAttrs_fb_text);
@@ -313,7 +317,7 @@ public class FancyButton  extends LinearLayout{
             mFontIcon = fontIcon;
 
         if(text!=null)
-            mText = text;
+            mText = mTextAllCaps ? text.toUpperCase():text;
 
         if(!isInEditMode()){
             if(iconFontFamily!=null){
@@ -426,11 +430,21 @@ public class FancyButton  extends LinearLayout{
      * @param text : Text
      */
     public void setText(String text){
+        text = mTextAllCaps ? text.toUpperCase() : text;
         this.mText = text;
         if(mTextView == null)
             initializeFancyButton();
         else
             mTextView.setText(text);
+    }
+
+    /** Set the capitalization of text
+     *
+     * @param textAllCaps : is text to be capitalized
+     */
+    public void setTextAllCaps(boolean textAllCaps){
+        this.mTextAllCaps = textAllCaps;
+        setText(mText);
     }
 
     /**

--- a/fancybuttons_library/src/main/res/values/attrs.xml
+++ b/fancybuttons_library/src/main/res/values/attrs.xml
@@ -54,6 +54,7 @@
         <attr name="fb_borderWidth" format="dimension"/>
         <attr name="fb_focusColor" format="color" />
         <attr name="fb_radius" format="dimension" />
+        <attr name="fb_textAllCaps" format="boolean" />
 
         <attr name="fb_ghost" format="boolean"></attr>
     </declare-styleable>


### PR DESCRIPTION
Fix for ripple effect issue as described in [issue 49](https://github.com/medyo/Fancybuttons/issues/49).