### PR TITLE
Minor improvement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 
 ### Changelog
 
+- 1.8.2
+    - Added ability to set disabled state color
+
 - 1.8.1
     - Fix Bug related to loading custom fonts
 
@@ -62,9 +65,9 @@
 	android:layout_width="wrap_content"
 	android:layout_height="wrap_content"/>
 
-####  Supported Attributs
+####  Supported Attributes
 
-| XML Attribut        | Java Attribut           | Description  |
+| XML Attribute        | Java Attribute           | Description  |
 | ------------- |:-------------:| -----:|
 | fancy:fb_text      | setText(String)     | Text of the button |
 | fancy:fb_textColor     | setTextColor(int)      |  Text Color of the button |
@@ -80,12 +83,23 @@
 | fancy:fb_borderColor | setBorderColor(int)      |    Color of the border|
 | fancy:fb_defaultColor | setBackgroundColor(int)      |    Background color of the button|
 | fancy:fb_focusColor | setFocusBackgroundColor(int)      |    Focus Color of border background|
+| fancy:fb_disabledColor | setDisableBackgroundColor(int)      |    Disable Color of border background|
 | fancy:fb_radius | setRadius(int)      |    Radius of the button|
 | fancy:fb_iconPaddingLeft | setIconPadding(int,int,int,int)      |    Icon Padding|
 | fancy:fb_iconPaddingRight | setIconPadding(int,int,int,int)      |    Icon Padding|
 | fancy:fb_iconPaddingTop | setIconPadding(int,int,int,int)      |    Icon Padding|
 | fancy:fb_iconPaddingBottom | setIconPadding(int,int,int,int)      |    Icon Padding|
 | fancy:fb_ghost | setGhost(boolean)      |    Ghost (Hollow)|
+
+Also you can use Attributes with default prefix (android:) which makes migrating of your project more fast.
+Default Attributes have more priority than Attributes with prefix fancy.
+
+#### Supported default Attributes
+| XML Attribute    |
+| ------------- |
+| android:enabled |
+| android:text (in progress) |
+| android:textSize (in progress) |
 
 ####  Supported Getters
 

--- a/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
+++ b/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/FancyButton.java
@@ -30,6 +30,7 @@ public class FancyButton  extends LinearLayout{
     // # Background Attributes
     private int mDefaultBackgroundColor 		= Color.BLACK;
     private int mFocusBackgroundColor 			= 0;
+    private int mDisabledBackgroundColor        = 0; //TODO need to implement with ripple effect
 
     // # Text Attributes
     private int mDefaultTextColor 				= Color.WHITE;
@@ -77,6 +78,7 @@ public class FancyButton  extends LinearLayout{
     private TextView mTextView;
 
     private boolean mGhost = false ; // Default is a solid button !
+    private boolean useRippleEffect = true;
 
     /**
      * Default constructor
@@ -103,7 +105,7 @@ public class FancyButton  extends LinearLayout{
         this.mContext = context;
 
         TypedArray attrsArray 	= context.obtainStyledAttributes(attrs,R.styleable.FancyButtonsAttrs, 0, 0);
-        initAttributesArray(attrsArray);
+        initAttributesArray(attrs, attrsArray);
         attrsArray.recycle();
 
         initializeFancyButton();
@@ -270,12 +272,16 @@ public class FancyButton  extends LinearLayout{
 
     /**
      * Initialize Attributes arrays
+     * @param attrs
      * @param attrsArray : Attributes array
      */
-    private void initAttributesArray(TypedArray attrsArray){
+    private void initAttributesArray(AttributeSet attrs, TypedArray attrsArray){
 
         mDefaultBackgroundColor 		= attrsArray.getColor(R.styleable.FancyButtonsAttrs_fb_defaultColor,mDefaultBackgroundColor);
         mFocusBackgroundColor 			= attrsArray.getColor(R.styleable.FancyButtonsAttrs_fb_focusColor,mFocusBackgroundColor);
+        mDisabledBackgroundColor        = attrsArray.getColor(R.styleable.FancyButtonsAttrs_fb_disabledColor, mDisabledBackgroundColor);
+
+        this.setEnabled(attrs.getAttributeBooleanValue("http://schemas.android.com/apk/res/android", "enabled", true));
 
         mDefaultTextColor 				= attrsArray.getColor(R.styleable.FancyButtonsAttrs_fb_textColor,mDefaultTextColor);
         // if default color is set then the icon's color is the same (the default for icon's color)
@@ -365,7 +371,7 @@ public class FancyButton  extends LinearLayout{
         }
 
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && useRippleEffect) {
 
             this.setBackground(getRippleDrawable(defaultDrawable, focusDrawable));
 
@@ -392,9 +398,15 @@ public class FancyButton  extends LinearLayout{
                 }
             }
 
+            // Disabled Drawable
+            GradientDrawable disabledDrawable = new GradientDrawable();
+            disabledDrawable.setCornerRadius(mRadius);
+            disabledDrawable.setColor(mDisabledBackgroundColor);
+
             if(mFocusBackgroundColor != 0){
                 states.addState(new int[] { android.R.attr.state_pressed }, drawable2);
                 states.addState(new int[] { android.R.attr.state_focused }, drawable2);
+                states.addState(new int[]{ -android.R.attr.state_enabled }, disabledDrawable);
             }
             states.addState(new int[]{}, defaultDrawable);
 
@@ -495,6 +507,18 @@ public class FancyButton  extends LinearLayout{
     public void setFocusBackgroundColor(int color){
         this.mFocusBackgroundColor = color;
         if(mIconView != null || mFontIconView != null || mTextView != null)
+            this.setupBackground();
+
+    }
+
+    /**
+     * Set Disabled state color of the button
+     *
+     * @param color : use Color.parse('#code')
+     */
+    public void setDisableBackgroundColor(int color) {
+        this.mDisabledBackgroundColor = color;
+        if (mIconView != null || mFontIconView != null || mTextView != null)
             this.setupBackground();
 
     }

--- a/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/Utils.java
+++ b/fancybuttons_library/src/main/java/mehdi/sakout/fancybuttons/Utils.java
@@ -21,9 +21,13 @@ public class Utils {
 		return Math.round(sp * context.getResources().getDisplayMetrics().scaledDensity);
 	}
 
-	public static Typeface findFont(Context context, String fonPath, String defaultFontPath){
+	public static Typeface findFont(Context context, String fontPath, String defaultFontPath){
 
-		String fontName = new File(fonPath).getName();
+		if (fontPath == null){
+			return Typeface.DEFAULT;
+		}
+
+		String fontName = new File(fontPath).getName();
 		String defaultFontName = "";
 		if (!TextUtils.isEmpty(defaultFontPath)){
 			defaultFontName = new File(defaultFontPath).getName();
@@ -35,7 +39,7 @@ public class Utils {
 			try{
 				AssetManager assets = context.getResources().getAssets();
 
-				if (Arrays.asList(assets.list("")).contains(fonPath)){
+				if (Arrays.asList(assets.list("")).contains(fontPath)){
 					Typeface typeface = Typeface.createFromAsset(context.getAssets(), fontName);
 					cachedFontMap.put(fontName, typeface);
 					return typeface;

--- a/fancybuttons_library/src/main/res/values/attrs.xml
+++ b/fancybuttons_library/src/main/res/values/attrs.xml
@@ -53,10 +53,11 @@
         <attr name="fb_borderColor" format="color" />
         <attr name="fb_borderWidth" format="dimension"/>
         <attr name="fb_focusColor" format="color" />
+        <attr name="fb_disabledColor" format="color" />
         <attr name="fb_radius" format="dimension" />
         <attr name="fb_textAllCaps" format="boolean" />
 
-        <attr name="fb_ghost" format="boolean"></attr>
+        <attr name="fb_ghost" format="boolean"/>
     </declare-styleable>
 
 </resources> 

--- a/samples/src/main/res/layout/activity_xml_buttons.xml
+++ b/samples/src/main/res/layout/activity_xml_buttons.xml
@@ -403,6 +403,26 @@
                     fancy:fb_textColor="#FFFFFF">
                 </mehdi.sakout.fancybuttons.FancyButton>
 
+                <mehdi.sakout.fancybuttons.FancyButton
+                    android:id="@+id/btn_twitter_disabled"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="10dp"
+                    android:padding="10dp"
+                    android:enabled="false"
+                    fancy:fb_borderColor="#FFFFFF"
+                    fancy:fb_borderWidth="2dp"
+                    fancy:fb_defaultColor="#40a75a"
+                    fancy:fb_focusColor="#8cc9f8"
+                    fancy:fb_disabledColor="#c8b7b7b7"
+                    fancy:fb_fontIconResource="@string/icon_user"
+                    fancy:fb_fontIconSize="30sp"
+                    fancy:fb_iconPosition="left"
+                    fancy:fb_text="Send disabled"
+                    fancy:fb_radius="10dp"
+                    fancy:fb_textColor="#FFFFFF">
+                </mehdi.sakout.fancybuttons.FancyButton>
+
             </LinearLayout>
 
             <LinearLayout


### PR DESCRIPTION
Added setting disabled state color (wors only wothout Ripple Effect)
Added ability to disable Ripple Effect
Added reading attribute android:enabled
Fixed bug with long layout inflating if there is no need font in assets (appears on some devices due to multiple attempts to find font). And if font was not found, every next inflating it trying to find it again. Need to make fix - memorize already searched fonts and don't search them again. May be will do it afterwards
